### PR TITLE
chore: reports/ フォルダを削除し proposals/ に統合

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,6 @@ proposals/
 ├── rejected/    ← 不採用
 └── on-hold/     ← 保留（追加調査待ち）
 templates/       ← 企画書テンプレート
-reports/         ← ダッシュボード・プロジェクト管理
 ```
 
 ## 操作元

--- a/README.md
+++ b/README.md
@@ -57,8 +57,6 @@ trillion-game-lab/
 │   ├── rejected/       ← 不採用
 │   └── on-hold/        ← 保留
 ├── templates/          ← テンプレート
-├── reports/            ← プロジェクト管理
-│   └── projects.json
 └── README.md
 ```
 

--- a/reports/projects.json
+++ b/reports/projects.json
@@ -1,5 +1,0 @@
-{
-  "company": "Trillion Game",
-  "department": "プロダクト企画部",
-  "projects": []
-}


### PR DESCRIPTION
## 概要

reports/ フォルダを削除し、ダッシュボード出力先を proposals/ に統合する。

## 変更内容

- `reports/projects.json`（中身が空）を削除
- `reports/` フォルダを削除
- `CLAUDE.md` と `README.md` のディレクトリ構成から reports を削除

## 理由

- `reports/` には `projects.json`（空配列）しかなく、実体がない
- `proposal-dashboard.md` は一度も生成されていない
- 企画データの実体は全て `proposals/` フォルダにある
- 本部リポ（trillion-game）のスキルで出力先を `proposals/proposal-dashboard.md` に変更する

## 後続作業

trillion-game リポ側で以下のスキル・コマンドの参照先を更新する:
- `.claude/skills/generate-dashboard.md`
- `.claude/skills/sort-proposals.md`
- `.claude/commands/projects/review-proposals.md`
- `CLAUDE.md` と `README.md`

Closes #22